### PR TITLE
Working minecraft server example (port 25565/tcp)

### DIFF
--- a/gateway/Dockerfile.gateway-client
+++ b/gateway/Dockerfile.gateway-client
@@ -6,7 +6,7 @@ RUN apk add gettext wireguard-tools caddy
 
 COPY client-entrypoint.sh /usr/bin/client-entrypoint.sh
 
-COPY Caddyfile.template /etc/Caddyfile.template
+COPY ./minecraft-server/nginx/minecraft.conf /etc/nginx/stream.conf
 
 ENV NOTEWORTHY_ENV $RELEASE_TAG
 ENV LINK_MTU=1380

--- a/gateway/Dockerfile.gateway-link
+++ b/gateway/Dockerfile.gateway-link
@@ -4,7 +4,7 @@ ARG RELEASE_TAG
 
 ADD link-entrypoint.sh /usr/bin/link-entrypoint.sh
 
-RUN apk add iptables socat wireguard-tools
+RUN apk add iptables socat wireguard-tools nginx nginx-mod-stream
 
 ENV NOTEWORTHY_ENV $RELEASE_TAG
 ENV LINK_MTU=1380

--- a/gateway/client-entrypoint.sh
+++ b/gateway/client-entrypoint.sh
@@ -14,5 +14,6 @@ ip link set link0 mtu $LINK_MTU
 
 wg set link0 peer $GATEWAY_LINK_WG_PUBKEY allowed-ips 10.0.0.1/32 persistent-keepalive 30 endpoint $GATEWAY_ENDPOINT
 
-envsubst < /etc/Caddyfile.template > /etc/Caddyfile
-caddy run --config /etc/Caddyfile
+# enable raw tcp proxying in nginx
+sed '/include/s/^#//' -i /etc/nginx/nginx.conf
+nginx -g 'daemon off;'

--- a/gateway/link-entrypoint.sh
+++ b/gateway/link-entrypoint.sh
@@ -29,5 +29,8 @@ iptables -t nat -A POSTROUTING -o link0 -p tcp --dport 8080 -j SNAT --to-source 
 iptables -t nat -A POSTROUTING -o link0 -p tcp --dport 8443 -j SNAT --to-source 10.0.0.1
 
 # generic udp proxies
-socat UDP4-RECVFROM:18522,fork UDP4-SENDTO:10.0.0.2:18522,sp=18524,reuseaddr &
-socat UDP4-RECVFROM:18523,fork UDP4-SENDTO:10.0.0.2:18522,sp=18525,reuseaddr
+#socat UDP4-RECVFROM:18522,fork UDP4-SENDTO:10.0.0.2:18522,sp=18524,reuseaddr &
+#socat UDP4-RECVFROM:18523,fork UDP4-SENDTO:10.0.0.2:18522,sp=18525,reuseaddr
+
+# Minecraft Java port
+socat TCP4-LISTEN:25565,fork,reuseaddr TCP4:10.0.0.2:25565

--- a/gateway/minecraft-server/docker-compose.yml
+++ b/gateway/minecraft-server/docker-compose.yml
@@ -1,0 +1,15 @@
+services:
+  minecraft:
+    image: itzg/minecraft-server
+    environment:
+      EULA: true
+  link:
+    image: fractalnetworks/gateway-client:latest
+    environment:
+      LINK_DOMAIN: minecraft.fractalnetworks.co
+      EXPOSE: nginx:80 # not used
+      GATEWAY_CLIENT_WG_PRIVKEY: OJxUG2BjTmsq6BpYt6qWERP79PvpiDSm/onqgukRJXQ=
+      GATEWAY_LINK_WG_PUBKEY: N4QHAGMTuKjfxWGYUvOl/V4MuzSmVO1TDQQb+UMX42I=
+      GATEWAY_ENDPOINT: 5.161.51.115:49153
+    cap_add:
+      - NET_ADMIN

--- a/gateway/minecraft-server/nginx/minecraft.conf
+++ b/gateway/minecraft-server/nginx/minecraft.conf
@@ -1,0 +1,6 @@
+stream {
+  server {
+    listen 25565;
+    proxy_pass minecraft:25565;
+  }
+}

--- a/gateway/scripts/_create-link.sh
+++ b/gateway/scripts/_create-link.sh
@@ -6,7 +6,7 @@ CONTAINER_NAME=$1
 LINK_CLIENT_WG_PUBKEY=$2
 
 # create gateway-link container
-CONTAINER_ID=$(docker run --name $CONTAINER_NAME --network gateway -p 18521/udp --cap-add NET_ADMIN --restart unless-stopped -it -e LINK_CLIENT_WG_PUBKEY=$LINK_CLIENT_WG_PUBKEY -d fractalnetworks/gateway-link:latest)
+CONTAINER_ID=$(docker run --name $CONTAINER_NAME --network gateway -p 25565 -p 18521/udp --cap-add NET_ADMIN --restart unless-stopped -it -e LINK_CLIENT_WG_PUBKEY=$LINK_CLIENT_WG_PUBKEY -d fractalnetworks/gateway-link:latest)
 # get gateway-link WireGuard pubkey 
 GATEWAY_LINK_WG_PUBKEY=$(docker exec $CONTAINER_NAME bash -c 'cat /etc/wireguard/link0.key |wg pubkey')
 # get randomly assigned WireGuard port


### PR DESCRIPTION
This PR demonstrates the modifications needed to proxy traffic to a local minecraft server with the selfhosted-gateway.